### PR TITLE
fix: use providers component and tailwind typography plugin

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,9 +5,11 @@ import { Inter } from "next/font/google";
 
 import { environment } from "@/environment.mjs";
 
-import "./style.css";
-
 import { cx } from "@/utilities/classname";
+
+import { Providers } from "./providers";
+
+import "./style.css";
 
 type RootLayoutProps = {
   children: ReactNode;
@@ -52,7 +54,9 @@ const RootLayout = ({ children }: RootLayoutProps) => (
     lang="en"
     suppressHydrationWarning
   >
-    <body>{children}</body>
+    <body>
+      <Providers>{children}</Providers>
+    </body>
   </html>
 );
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,10 +1,11 @@
+import tailwindCssTypography from "@tailwindcss/typography";
 import type { Config } from "tailwindcss";
 import tailwindCssAnimate from "tailwindcss-animate";
 import { fontFamily } from "tailwindcss/defaultTheme";
 
 const tailwindCssConfig: Config = {
   content: ["./src/**/*.{js,jsx,mdx,ts,tsx}"],
-  plugins: [tailwindCssAnimate],
+  plugins: [tailwindCssAnimate, tailwindCssTypography],
   theme: {
     extend: {
       fontFamily: {


### PR DESCRIPTION
This pull request adds missing `<Providers>`  component in the root layout and [`@tailwindcss/typography`](https://tailwindcss.com/docs/typography-plugin) plugin to the [configuration file](https://tailwindcss.com/docs/configuration).